### PR TITLE
Add tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# looker
+
+A lens for removing glare and reducing eye strain while looking at Bunyan logs.
+
+## Usage
+
+See `looker --help` for usage options.
+
+## Filtering with RHAI
+
+The `-c` option accepts an [RHAI script](https://rhai.rs) that returns a Boolean
+value indicating whether a record should be displayed. Each record is supplied
+to the script in a variable named `r`.
+
+The following Bunyan fields are guaranteed to exist for all records: `level`,
+`name`, `hostname`, `pid`, `time`, and `msg`. Other fields, including
+`component`, are optional and must be followed by the `?` operator for RHAI to
+compile a script referring to them. Records that don't have a field referred to
+in the script will be elided.
+
+### Examples
+
+- `looker -c 'r.msg.contains("Failed")'` - include all lines with a `msg` that
+  contains `Failed`
+- `looker -c 'r.response_code?.parse_int() >= 500'` - include all lines with a
+  `response_code` field in the 5XX level

--- a/src/bunyan.rs
+++ b/src/bunyan.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::{Level, Record, level, bold, Format};
+
+#[derive(Deserialize, Debug)]
+pub struct BunyanEntry {
+    pub v: i64,
+    pub level: Level,
+    pub name: String,
+    pub hostname: String,
+    pub pid: u64,
+    pub time: DateTime<Utc>,
+    pub msg: String,
+
+    /*
+     * This is not a part of the base specification, but is widely used:
+     */
+    pub component: Option<String>,
+
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl Record for BunyanEntry {
+    fn level(&self) -> Level {
+        self.level
+    }
+
+    fn emit_record(
+            &self,
+            colour: crate::Colour,
+            fmt: crate::Format,
+            lookups: &Vec<String>,
+    ) -> anyhow::Result<()> {
+        let l = level(self.level, colour);
+        let mut n = bold(&self.name, colour);
+        if matches!(fmt, Format::Long) {
+            n += &format!("/{}", self.pid);
+        }
+        if let Some(c) = &self.component {
+            if c != &self.name {
+                n += &format!(" ({})", c);
+            }
+        };
+
+        /*
+            * For multi-line messages, indent subsequent lines by 4 spaces, so that
+            * they are at least somewhat distinguishable from the next log message.
+            */
+        let msg = self
+            .msg
+            .lines()
+            .enumerate()
+            .map(|(i, l)| {
+                let mut s = if i > 0 { "    " } else { "" }.to_string();
+                s.push_str(l);
+                s
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        match fmt {
+            Format::Short => {
+                let d = self.time.format("%H:%M:%S%.3fZ").to_string();
+                println!("{:13} {} {}: {}", d, l, n, msg);
+            }
+            Format::Long => {
+                let d = self.time.format("%Y-%m-%d %H:%M:%S%.3fZ").to_string();
+                println!("{} {} {} on {}: {}", d, l, n, self.hostname, msg);
+            }
+            Format::Bare => unreachable!(),
+        }
+
+        for (k, v) in self.extra.iter() {
+            if !lookups.is_empty() && !lookups.contains(k) {
+                continue;
+            }
+
+            print!("    {} = ", bold(k.as_str(), colour));
+
+            match v {
+                serde_json::Value::Null => println!("null"),
+                serde_json::Value::Bool(v) => println!("{}", v),
+                serde_json::Value::Number(n) => println!("{}", n),
+                serde_json::Value::String(s) => {
+                    let mut out = String::new();
+                    for c in s.chars() {
+                        if c != '"' && c != '\'' {
+                            out.push_str(&c.escape_default().to_string());
+                        } else {
+                            out.push(c);
+                        }
+                    }
+                    println!("{}", out);
+                }
+                serde_json::Value::Array(a) => println!("{:?}", a),
+                serde_json::Value::Object(o) => println!("{:?}", o),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/bunyan.rs
+++ b/src/bunyan.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use crate::{Level, Record, level, bold, Format};
+use crate::{bold, level, Format, Level, Record};
 
 #[derive(Deserialize, Debug)]
 pub struct BunyanEntry {
@@ -30,10 +30,10 @@ impl Record for BunyanEntry {
     }
 
     fn emit_record(
-            &self,
-            colour: crate::Colour,
-            fmt: crate::Format,
-            lookups: &Vec<String>,
+        &self,
+        colour: crate::Colour,
+        fmt: crate::Format,
+        lookups: &Vec<String>,
     ) -> anyhow::Result<()> {
         let l = level(self.level, colour);
         let mut n = bold(&self.name, colour);
@@ -47,9 +47,9 @@ impl Record for BunyanEntry {
         };
 
         /*
-            * For multi-line messages, indent subsequent lines by 4 spaces, so that
-            * they are at least somewhat distinguishable from the next log message.
-            */
+         * For multi-line messages, indent subsequent lines by 4 spaces, so that
+         * they are at least somewhat distinguishable from the next log message.
+         */
         let msg = self
             .msg
             .lines()

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,8 @@ fn main() -> Result<()> {
         "c",
         "",
         "filter the input with a rhai script that returns a \
-        boolean expression: true to include or false to elide",
+        boolean expression: true to include or false to elide; \
+        use `r` to refer to the record under consideration",
         "SCRIPT",
     );
     opts.optopt("f", "", "read input from a file rather than stdin", "FILE");

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ impl Entry {
     fn as_record(&self) -> &dyn Record {
         match self {
             Entry::Bunyan(be) => be,
-            Entry::Tracing(tr) => tr
+            Entry::Tracing(tr) => tr,
         }
     }
 }
@@ -318,8 +318,7 @@ fn main() -> Result<()> {
         }
     };
 
-    let level =
-        a.opt_str("l").as_deref().map(Level::from_str).transpose()?;
+    let level = a.opt_str("l").as_deref().map(Level::from_str).transpose()?;
 
     let colour = if a.opt_present("N") {
         Colour::None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
 use std::{
-    collections::BTreeMap,
     io::{BufRead, BufReader, Read},
     str::FromStr,
 };
 
 use anyhow::{anyhow, bail, Result};
-use chrono::prelude::*;
+use bunyan::BunyanEntry;
 use rhai::{Dynamic, Engine, Scope, AST};
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
+use tracing::TracingEntry;
+
+mod bunyan;
+mod tracing;
 
 #[derive(Clone, Copy)]
 enum Format {
@@ -24,28 +27,9 @@ enum Colour {
     C256,
 }
 
-#[derive(Deserialize, Debug)]
-struct BunyanEntry {
-    v: i64,
-    level: BunyanLevel,
-    name: String,
-    hostname: String,
-    pid: u64,
-    time: DateTime<Utc>,
-    msg: String,
-
-    /*
-     * This is not a part of the base specification, but is widely used:
-     */
-    component: Option<String>,
-
-    #[serde(flatten)]
-    extra: BTreeMap<String, serde_json::Value>,
-}
-
-#[derive(Deserialize_repr, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Deserialize_repr, Debug, PartialEq, PartialOrd)]
 #[repr(u8)]
-enum BunyanLevel {
+pub enum Level {
     Fatal = 60,
     Error = 50,
     Warn = 40,
@@ -54,7 +38,7 @@ enum BunyanLevel {
     Trace = 10,
 }
 
-impl FromStr for BunyanLevel {
+impl FromStr for Level {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -65,40 +49,40 @@ impl FromStr for BunyanLevel {
          * level logs.
          */
         Ok(match s.trim().to_ascii_lowercase().as_str() {
-            "60" | "fatal" | "fata" => BunyanLevel::Fatal,
-            "50" | "error" | "erro" => BunyanLevel::Error,
-            "40" | "warn" => BunyanLevel::Warn,
-            "30" | "info" => BunyanLevel::Info,
-            "20" | "debug" | "debg" => BunyanLevel::Debug,
-            "10" | "trace" | "trac" => BunyanLevel::Trace,
+            "60" | "fatal" | "fata" => Level::Fatal,
+            "50" | "error" | "erro" => Level::Error,
+            "40" | "warn" => Level::Warn,
+            "30" | "info" => Level::Info,
+            "20" | "debug" | "debg" => Level::Debug,
+            "10" | "trace" | "trac" => Level::Trace,
             other => bail!("unknown level {:?}", other),
         })
     }
 }
 
-impl BunyanLevel {
+impl Level {
     fn ansi_colour(&self, colour: Colour) -> String {
         match colour {
             Colour::None => "".to_string(),
             Colour::C16 => {
                 let n = match self {
-                    BunyanLevel::Fatal => 93,
-                    BunyanLevel::Error => 91,
-                    BunyanLevel::Warn => 95,
-                    BunyanLevel::Info => 96,
-                    BunyanLevel::Debug => 94,
-                    BunyanLevel::Trace => 92,
+                    Level::Fatal => 93,
+                    Level::Error => 91,
+                    Level::Warn => 95,
+                    Level::Info => 96,
+                    Level::Debug => 94,
+                    Level::Trace => 92,
                 };
                 format!("\x1b[{}m", n)
             }
             Colour::C256 => {
                 let n = match self {
-                    BunyanLevel::Fatal => 190,
-                    BunyanLevel::Error => 160,
-                    BunyanLevel::Warn => 130,
-                    BunyanLevel::Info => 28,
-                    BunyanLevel::Debug => 44,
-                    BunyanLevel::Trace => 69,
+                    Level::Fatal => 190,
+                    Level::Error => 160,
+                    Level::Warn => 130,
+                    Level::Info => 28,
+                    Level::Debug => 44,
+                    Level::Trace => 69,
                 };
                 format!("\x1b[38;5;{}m", n)
             }
@@ -107,12 +91,12 @@ impl BunyanLevel {
 
     fn render(&self) -> &'static str {
         match self {
-            BunyanLevel::Fatal => "FATA",
-            BunyanLevel::Error => "ERRO",
-            BunyanLevel::Warn => "WARN",
-            BunyanLevel::Info => "INFO",
-            BunyanLevel::Debug => "DEBG",
-            BunyanLevel::Trace => "TRAC",
+            Level::Fatal => "FATA",
+            Level::Error => "ERRO",
+            Level::Warn => "WARN",
+            Level::Info => "INFO",
+            Level::Debug => "DEBG",
+            Level::Trace => "TRAC",
         }
     }
 }
@@ -130,7 +114,7 @@ fn bold(input: &str, colour: Colour) -> String {
     s
 }
 
-fn level(bl: BunyanLevel, colour: Colour) -> String {
+fn level(bl: Level, colour: Colour) -> String {
     bold(&format!("{}{}", bl.ansi_colour(colour), bl.render()), colour)
 }
 
@@ -163,81 +147,6 @@ fn emit_bare(j: serde_json::Value, lookups: &Vec<String>) -> Result<()> {
     }
 
     println!("{}", outs.join(" "));
-    Ok(())
-}
-
-fn emit_record(
-    be: BunyanEntry,
-    colour: Colour,
-    fmt: Format,
-    lookups: &Vec<String>,
-) -> Result<()> {
-    let l = level(be.level, colour);
-    let mut n = bold(&be.name, colour);
-    if matches!(fmt, Format::Long) {
-        n += &format!("/{}", be.pid);
-    }
-    if let Some(c) = &be.component {
-        if c != &be.name {
-            n += &format!(" ({})", c);
-        }
-    };
-
-    /*
-     * For multi-line messages, indent subsequent lines by 4 spaces, so that
-     * they are at least somewhat distinguishable from the next log message.
-     */
-    let msg = be
-        .msg
-        .lines()
-        .enumerate()
-        .map(|(i, l)| {
-            let mut s = if i > 0 { "    " } else { "" }.to_string();
-            s.push_str(l);
-            s
-        })
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    match fmt {
-        Format::Short => {
-            let d = be.time.format("%H:%M:%S%.3fZ").to_string();
-            println!("{:13} {} {}: {}", d, l, n, msg);
-        }
-        Format::Long => {
-            let d = be.time.format("%Y-%m-%d %H:%M:%S%.3fZ").to_string();
-            println!("{} {} {} on {}: {}", d, l, n, be.hostname, msg);
-        }
-        Format::Bare => unreachable!(),
-    }
-
-    for (k, v) in be.extra.iter() {
-        if !lookups.is_empty() && !lookups.contains(k) {
-            continue;
-        }
-
-        print!("    {} = ", bold(k.as_str(), colour));
-
-        match v {
-            serde_json::Value::Null => println!("null"),
-            serde_json::Value::Bool(v) => println!("{}", v),
-            serde_json::Value::Number(n) => println!("{}", n),
-            serde_json::Value::String(s) => {
-                let mut out = String::new();
-                for c in s.chars() {
-                    if c != '"' && c != '\'' {
-                        out.push_str(&c.escape_default().to_string());
-                    } else {
-                        out.push(c);
-                    }
-                }
-                println!("{}", out);
-            }
-            serde_json::Value::Array(a) => println!("{:?}", a),
-            serde_json::Value::Object(o) => println!("{:?}", o),
-        }
-    }
-
     Ok(())
 }
 
@@ -293,6 +202,33 @@ fn parse_filter(s: String) -> Result<Filter<'static>> {
         .map_err(|e| anyhow!("compiling script: {e}"))?;
 
     Ok(Filter { engine, ast, scope })
+}
+
+trait Record {
+    fn level(&self) -> Level;
+
+    fn emit_record(
+        &self,
+        colour: Colour,
+        fmt: Format,
+        lookups: &Vec<String>,
+    ) -> Result<()>;
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Entry {
+    Bunyan(BunyanEntry),
+    Tracing(TracingEntry),
+}
+
+impl Entry {
+    fn as_record(&self) -> &dyn Record {
+        match self {
+            Entry::Bunyan(be) => be,
+            Entry::Tracing(tr) => tr
+        }
+    }
 }
 
 fn main() -> Result<()> {
@@ -383,7 +319,7 @@ fn main() -> Result<()> {
     };
 
     let level =
-        a.opt_str("l").as_deref().map(BunyanLevel::from_str).transpose()?;
+        a.opt_str("l").as_deref().map(Level::from_str).transpose()?;
 
     let colour = if a.opt_present("N") {
         Colour::None
@@ -399,10 +335,22 @@ fn main() -> Result<()> {
     while let Some(l) = lines.next().transpose()? {
         match serde_json::from_str::<serde_json::Value>(&l) {
             Ok(j) => {
-                match serde_json::from_value::<BunyanEntry>(j.clone()) {
-                    Ok(be) if be.v == 0 => {
+                match serde_json::from_value::<Entry>(j.clone()) {
+                    Ok(Entry::Bunyan(be)) if be.v != 0 => {
+                        if matches!(format, Format::Bare) || filter.is_some() {
+                            continue;
+                        }
+
+                        /*
+                         * Unrecognised major version in this bunyan record.
+                         */
+                        println!("{}", l);
+                    }
+                    Ok(entry) => {
+                        let record = entry.as_record();
+
                         if let Some(level) = &level {
-                            if &be.level < level {
+                            if &record.level() < level {
                                 continue;
                             }
                         }
@@ -448,18 +396,8 @@ fn main() -> Result<()> {
                         if matches!(format, Format::Bare) {
                             emit_bare(j, lookups)?;
                         } else {
-                            emit_record(be, colour, format, lookups)?;
+                            record.emit_record(colour, format, lookups)?;
                         }
-                    }
-                    Ok(_) => {
-                        if matches!(format, Format::Bare) || filter.is_some() {
-                            continue;
-                        }
-
-                        /*
-                         * Unrecognised major version in this bunyan record.
-                         */
-                        println!("{}", l);
                     }
                     Err(_) => {
                         if matches!(format, Format::Bare) || filter.is_some() {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::{Record, Colour, Format, Level, level, bold};
+use crate::{bold, level, Colour, Format, Level, Record};
 
 #[derive(Deserialize, Debug)]
 pub struct TracingEntry {
@@ -58,18 +58,18 @@ impl Record for TracingEntry {
     }
 
     fn emit_record(
-            &self,
-            colour: Colour,
-            fmt: Format,
-            lookups: &Vec<String>,
-        ) -> anyhow::Result<()> {
+        &self,
+        colour: Colour,
+        fmt: Format,
+        lookups: &Vec<String>,
+    ) -> anyhow::Result<()> {
         let l = level(self.level.into(), colour);
         let n = bold(&self.target, colour);
 
         /*
-            * For multi-line messages, indent subsequent lines by 4 spaces, so that
-            * they are at least somewhat distinguishable from the next log message.
-            */
+         * For multi-line messages, indent subsequent lines by 4 spaces, so that
+         * they are at least somewhat distinguishable from the next log message.
+         */
         let msg = self
             .fields
             .message
@@ -89,7 +89,8 @@ impl Record for TracingEntry {
                 println!("{:13} {} {}: {}", d, l, n, msg);
             }
             Format::Long => {
-                let d = self.timestamp.format("%Y-%m-%d %H:%M:%S%.3fZ").to_string();
+                let d =
+                    self.timestamp.format("%Y-%m-%d %H:%M:%S%.3fZ").to_string();
                 println!("{} {} {}: {}", d, l, n, msg);
             }
             Format::Bare => unreachable!(),
@@ -133,18 +134,17 @@ impl Record for TracingEntry {
 }
 
 impl Span {
-    fn emit_span(
-        &self,
-        prefix: &str,
-        colour: Colour,
-        lookups: &Vec<String>
-    ) {
+    fn emit_span(&self, prefix: &str, colour: Colour, lookups: &Vec<String>) {
         for (k, v) in self.values.iter() {
             if !lookups.is_empty() && !lookups.contains(k) {
                 continue;
             }
 
-            print!("    {}::{} = ", bold(prefix, colour), bold(k.as_str(), colour));
+            print!(
+                "    {}::{} = ",
+                bold(prefix, colour),
+                bold(k.as_str(), colour)
+            );
 
             match v {
                 serde_json::Value::Null => println!("null"),

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -147,8 +147,7 @@ impl Span {
             }
 
             print!(
-                "    {}::{} = ",
-                bold(&format!("span[{}]", index), colour),
+                "        {} = ",
                 bold(k.as_str(), colour)
             );
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -125,7 +125,7 @@ impl Record for TracingEntry {
 
         if let Some(spans) = &self.spans {
             for (i, span) in spans.iter().enumerate() {
-                span.emit_span(&format!("span[{}]", i), colour, lookups);
+                span.emit_span(i, colour, lookups);
             }
         }
 
@@ -134,7 +134,13 @@ impl Record for TracingEntry {
 }
 
 impl Span {
-    fn emit_span(&self, prefix: &str, colour: Colour, lookups: &Vec<String>) {
+    fn emit_span(&self, index: usize, colour: Colour, lookups: &Vec<String>) {
+        println!(
+            "    {} = {}",
+            bold(&format!("span[{}]", index), colour),
+            self.name
+        );
+
         for (k, v) in self.values.iter() {
             if !lookups.is_empty() && !lookups.contains(k) {
                 continue;
@@ -142,7 +148,7 @@ impl Span {
 
             print!(
                 "    {}::{} = ",
-                bold(prefix, colour),
+                bold(&format!("span[{}]", index), colour),
                 bold(k.as_str(), colour)
             );
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,169 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{Record, Colour, Format, Level, level, bold};
+
+#[derive(Deserialize, Debug)]
+pub struct TracingEntry {
+    pub timestamp: DateTime<Utc>,
+    pub level: TracingLevel,
+    pub target: String,
+    pub fields: Fields,
+    pub span: Option<Span>,
+    pub spans: Option<Vec<Span>>,
+}
+
+#[derive(Copy, Clone, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TracingLevel {
+    Debug,
+    Error,
+    Info,
+    Warn,
+    Trace,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Fields {
+    pub message: String,
+    #[serde(flatten)]
+    pub values: BTreeMap<String, Value>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Span {
+    pub name: String,
+    #[serde(flatten)]
+    pub values: BTreeMap<String, Value>,
+}
+
+impl From<TracingLevel> for Level {
+    fn from(value: TracingLevel) -> Self {
+        match value {
+            TracingLevel::Debug => Level::Debug,
+            TracingLevel::Error => Level::Error,
+            TracingLevel::Info => Level::Info,
+            TracingLevel::Warn => Level::Warn,
+            TracingLevel::Trace => Level::Trace,
+        }
+    }
+}
+
+impl Record for TracingEntry {
+    fn level(&self) -> Level {
+        self.level.into()
+    }
+
+    fn emit_record(
+            &self,
+            colour: Colour,
+            fmt: Format,
+            lookups: &Vec<String>,
+        ) -> anyhow::Result<()> {
+        let l = level(self.level.into(), colour);
+        let n = bold(&self.target, colour);
+
+        /*
+            * For multi-line messages, indent subsequent lines by 4 spaces, so that
+            * they are at least somewhat distinguishable from the next log message.
+            */
+        let msg = self
+            .fields
+            .message
+            .lines()
+            .enumerate()
+            .map(|(i, l)| {
+                let mut s = if i > 0 { "    " } else { "" }.to_string();
+                s.push_str(l);
+                s
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        match fmt {
+            Format::Short => {
+                let d = self.timestamp.format("%H:%M:%S%.3fZ").to_string();
+                println!("{:13} {} {}: {}", d, l, n, msg);
+            }
+            Format::Long => {
+                let d = self.timestamp.format("%Y-%m-%d %H:%M:%S%.3fZ").to_string();
+                println!("{} {} {}: {}", d, l, n, msg);
+            }
+            Format::Bare => unreachable!(),
+        }
+
+        for (k, v) in self.fields.values.iter() {
+            if !lookups.is_empty() && !lookups.contains(k) {
+                continue;
+            }
+
+            print!("    {} = ", bold(k.as_str(), colour));
+
+            match v {
+                serde_json::Value::Null => println!("null"),
+                serde_json::Value::Bool(v) => println!("{}", v),
+                serde_json::Value::Number(n) => println!("{}", n),
+                serde_json::Value::String(s) => {
+                    let mut out = String::new();
+                    for c in s.chars() {
+                        if c != '"' && c != '\'' {
+                            out.push_str(&c.escape_default().to_string());
+                        } else {
+                            out.push(c);
+                        }
+                    }
+                    println!("{}", out);
+                }
+                serde_json::Value::Array(a) => println!("{:?}", a),
+                serde_json::Value::Object(o) => println!("{:?}", o),
+            }
+        }
+
+        if let Some(spans) = &self.spans {
+            for (i, span) in spans.iter().enumerate() {
+                span.emit_span(&format!("span[{}]", i), colour, lookups);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Span {
+    fn emit_span(
+        &self,
+        prefix: &str,
+        colour: Colour,
+        lookups: &Vec<String>
+    ) {
+        for (k, v) in self.values.iter() {
+            if !lookups.is_empty() && !lookups.contains(k) {
+                continue;
+            }
+
+            print!("    {}::{} = ", bold(prefix, colour), bold(k.as_str(), colour));
+
+            match v {
+                serde_json::Value::Null => println!("null"),
+                serde_json::Value::Bool(v) => println!("{}", v),
+                serde_json::Value::Number(n) => println!("{}", n),
+                serde_json::Value::String(s) => {
+                    let mut out = String::new();
+                    for c in s.chars() {
+                        if c != '"' && c != '\'' {
+                            out.push_str(&c.escape_default().to_string());
+                        } else {
+                            out.push(c);
+                        }
+                    }
+                    println!("{}", out);
+                }
+                serde_json::Value::Array(a) => println!("{:?}", a),
+                serde_json::Value::Object(o) => println!("{:?}", o),
+            }
+        }
+    }
+}

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -63,7 +63,7 @@ impl Record for TracingEntry {
         fmt: Format,
         lookups: &Vec<String>,
     ) -> anyhow::Result<()> {
-        let l = level(self.level.into(), colour);
+        let l = level(self.level(), colour);
         let n = bold(&self.target, colour);
 
         /*

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -28,7 +28,7 @@ pub enum TracingLevel {
 
 #[derive(Deserialize, Debug)]
 pub struct Fields {
-    pub message: String,
+    pub message: Option<String>,
     #[serde(flatten)]
     pub values: BTreeMap<String, Value>,
 }
@@ -73,6 +73,8 @@ impl Record for TracingEntry {
         let msg = self
             .fields
             .message
+            .as_deref()
+            .unwrap_or("")
             .lines()
             .enumerate()
             .map(|(i, l)| {


### PR DESCRIPTION
Really liked using `looker` with nexus logs and wanted to use it on json formatted tracing logs.

* Add support for different source entry types
* Add support for reading and emitting tracing logs